### PR TITLE
Group knobs

### DIFF
--- a/addons/knobs/README.md
+++ b/addons/knobs/README.md
@@ -123,8 +123,9 @@ import { text } from '@storybook/addon-knobs/react';
 
 const label = 'Your Name';
 const defaultValue = 'Arunoda Susiripala';
+const groupId = 'GROUP-ID1';
 
-const value = text(label, defaultValue);
+const value = text(label, defaultValue, groupId);
 ```
 
 ### boolean
@@ -136,8 +137,9 @@ import { boolean } from '@storybook/addon-knobs/react';
 
 const label = 'Agree?';
 const defaultValue = false;
+const groupId = 'GROUP-ID1';
 
-const value = boolean(label, defaultValue);
+const value = boolean(label, defaultValue, groupId);
 ```
 
 ### number
@@ -149,8 +151,9 @@ import { number } from '@storybook/addon-knobs/react';
 
 const label = 'Age';
 const defaultValue = 78;
+const groupId = 'GROUP-ID1';
 
-const value = number(label, defaultValue);
+const value = number(label, defaultValue, groupId);
 ```
 
 ### number bound by range
@@ -168,8 +171,9 @@ const options = {
    max: 90,
    step: 1,
 };
+const groupId = 'GROUP-ID1';
 
-const value = number(label, defaultValue, options);
+const value = number(label, defaultValue, options, groupId);
 ```
 
 ### color
@@ -181,8 +185,9 @@ import { color } from '@storybook/addon-knobs/react';
 
 const label = 'Color';
 const defaultValue = '#ff00ff';
+const groupId = 'GROUP-ID1';
 
-const value = color(label, defaultValue);
+const value = color(label, defaultValue, groupId);
 ```
 
 ### object
@@ -196,8 +201,9 @@ const label = 'Styles';
 const defaultValue = {
   backgroundColor: 'red'
 };
+const groupId = 'GROUP-ID1';
 
-const value = object(label, defaultValue);
+const value = object(label, defaultValue, groupId);
 ```
 
 > Make sure to enter valid JSON syntax while editing values inside the knob.
@@ -210,7 +216,8 @@ Allows you to get an array of strings from the user.
 import { array } from '@storybook/addon-knobs/react';
 
 const label = 'Styles';
-const defaultValue = ['Red']
+const defaultValue = ['Red'];
+const groupId = 'GROUP-ID1';
 
 const value = array(label, defaultValue);
 ```
@@ -224,7 +231,8 @@ const value = array(label, defaultValue);
 > const label = 'Styles';
 > const defaultValue = ['Red'];
 > const separator = ':';
-> const value = array(label, defaultValue, separator);
+> const groupId = 'GROUP-ID1';
+> const value = array(label, defaultValue, separator, groupId);
 > ```
 
 ### select
@@ -241,8 +249,9 @@ const options = {
   yellow: 'Yellow',
 };
 const defaultValue = 'red';
+const groupId = 'GROUP-ID1';
 
-const value = select(label, options, defaultValue);
+const value = select(label, options, defaultValue, groupId);
 ```
 
 > You can also provide options as an array like this: `['red', 'blue', 'yellow']`
@@ -256,7 +265,9 @@ import { date } from '@storybook/addon-knobs/react';
 
 const label = 'Event Date';
 const defaultValue = new Date('Jan 20 2017');
-const value = date(label, defaultValue);
+const groupId = 'GROUP-ID1';
+
+const value = date(label, defaultValue, groupId);
 ```
 
 > Note: the default value must not change - e.g., do not do `date('Label', new Date())` or `date('Label')`
@@ -280,7 +291,9 @@ import { button } from '@storybook/addon-knobs';
 
 const label = 'Do Something';
 const handler = () => doSomething('foobar');
-button(label, handler);
+const groupId = 'GROUP-ID1';
+
+button(label, handler, groupId);
 ```
 
 ### withKnobs vs withKnobsOptions

--- a/addons/knobs/README.md
+++ b/addons/knobs/README.md
@@ -153,7 +153,7 @@ const label = 'Age';
 const defaultValue = 78;
 const groupId = 'GROUP-ID1';
 
-const value = number(label, defaultValue, groupId);
+const value = number(label, defaultValue, {}, groupId);
 ```
 
 ### number bound by range
@@ -219,7 +219,7 @@ const label = 'Styles';
 const defaultValue = ['Red'];
 const groupId = 'GROUP-ID1';
 
-const value = array(label, defaultValue);
+const value = array(label, defaultValue, ',', groupId);
 ```
 
 > While editing values inside the knob, you will need to use a separator.

--- a/addons/knobs/package.json
+++ b/addons/knobs/package.json
@@ -15,6 +15,7 @@
     "storybook": "start-storybook -p 9010"
   },
   "dependencies": {
+    "@storybook/components": "^3.3.3",
     "babel-runtime": "^6.26.0",
     "deep-equal": "^1.0.1",
     "global": "^4.3.2",

--- a/addons/knobs/src/KnobStore.js
+++ b/addons/knobs/src/KnobStore.js
@@ -11,6 +11,7 @@ export default class KnobStore {
   set(key, value) {
     this.store[key] = value;
     this.store[key].used = true;
+    this.store[key].groupId = value.groupId;
     this.callbacks.forEach(cb => cb());
   }
 

--- a/addons/knobs/src/base.js
+++ b/addons/knobs/src/base.js
@@ -6,15 +6,15 @@ export function knob(name, options) {
   return manager.knob(name, options);
 }
 
-export function text(name, value) {
-  return manager.knob(name, { type: 'text', value });
+export function text(name, value, groupId) {
+  return manager.knob(name, { type: 'text', value, groupId });
 }
 
-export function boolean(name, value) {
-  return manager.knob(name, { type: 'boolean', value });
+export function boolean(name, value, groupId) {
+  return manager.knob(name, { type: 'boolean', value, groupId });
 }
 
-export function number(name, value, options = {}) {
+export function number(name, value, options = {}, groupId) {
   const rangeDefaults = {
     min: 0,
     max: 10,
@@ -32,32 +32,33 @@ export function number(name, value, options = {}) {
     ...mergedOptions,
     type: 'number',
     value,
+    groupId,
   };
 
   return manager.knob(name, finalOptions);
 }
 
-export function color(name, value) {
-  return manager.knob(name, { type: 'color', value });
+export function color(name, value, groupId) {
+  return manager.knob(name, { type: 'color', value, groupId });
 }
 
-export function object(name, value) {
-  return manager.knob(name, { type: 'object', value });
+export function object(name, value, groupId) {
+  return manager.knob(name, { type: 'object', value, groupId });
 }
 
-export function select(name, options, value) {
-  return manager.knob(name, { type: 'select', options, value });
+export function select(name, options, value, groupId) {
+  return manager.knob(name, { type: 'select', options, value, groupId });
 }
 
-export function array(name, value, separator = ',') {
-  return manager.knob(name, { type: 'array', value, separator });
+export function array(name, value, separator = ',', groupId) {
+  return manager.knob(name, { type: 'array', value, separator, groupId });
 }
 
-export function date(name, value = new Date()) {
+export function date(name, value = new Date(), groupId) {
   const proxyValue = value ? value.getTime() : null;
-  return manager.knob(name, { type: 'date', value: proxyValue });
+  return manager.knob(name, { type: 'date', value: proxyValue, groupId });
 }
 
-export function button(name, callback) {
-  return manager.knob(name, { type: 'button', callback, hideLabel: true });
+export function button(name, callback, groupId) {
+  return manager.knob(name, { type: 'button', callback, hideLabel: true, groupId });
 }

--- a/addons/knobs/src/components/GroupTabs.js
+++ b/addons/knobs/src/components/GroupTabs.js
@@ -1,0 +1,142 @@
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { baseFonts } from '@storybook/components';
+
+const styles = {
+  empty: {
+    flex: 1,
+    display: 'flex',
+    ...baseFonts,
+    fontSize: 11,
+    letterSpacing: '1px',
+    textTransform: 'uppercase',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+
+  wrapper: {
+    flex: '1 1 auto',
+    display: 'flex',
+    flexDirection: 'column',
+    background: 'white',
+    borderRadius: 4,
+    border: 'solid 1px rgb(236, 236, 236)',
+    marginTop: 5,
+    width: '100%',
+  },
+
+  tabbar: {
+    display: 'flex',
+    flexWrap: 'wrap',
+    flexDirection: 'row',
+    justifyContent: 'flex-start',
+    alignItems: 'center',
+    borderBottom: 'solid 1px #eaeaea',
+  },
+
+  content: {
+    flex: '1 1 0',
+    display: 'flex',
+    overflow: 'auto',
+  },
+
+  tablink: {
+    ...baseFonts,
+    fontSize: 11,
+    letterSpacing: '1px',
+    padding: '10px 15px',
+    textTransform: 'uppercase',
+    transition: 'opacity 0.3s',
+    opacity: 0.5,
+    maxHeight: 60,
+    overflow: 'hidden',
+    cursor: 'pointer',
+    background: 'transparent',
+    border: 'none',
+  },
+
+  activetab: {
+    opacity: 1,
+  },
+};
+
+class GroupTabs extends Component {
+  renderTab(name, group) {
+    let tabStyle = styles.tablink;
+    if (this.props.selectedGroup === name) {
+      tabStyle = Object.assign({}, styles.tablink, styles.activetab);
+    }
+
+    const onClick = e => {
+      e.preventDefault();
+      this.props.onGroupSelect(name);
+    };
+
+    let { title } = group;
+    if (typeof title === 'function') {
+      title = title();
+    }
+
+    return (
+      <button type="button" key={name} style={tabStyle} onClick={onClick} role="tab">
+        {title}
+      </button>
+    );
+  }
+
+  renderTabs() {
+    return Object.keys(this.props.groups).map(name => {
+      const group = this.props.groups[name];
+      return this.renderTab(name, group);
+    });
+  }
+
+  renderGroups() {
+    return Object.keys(this.props.groups)
+      .sort()
+      .map(name => {
+        const groupStyle = { display: 'none' };
+        const group = this.props.groups[name];
+        if (name === this.props.selectedGroup) {
+          Object.assign(groupStyle, { flex: 1, display: 'flex' });
+        }
+        return (
+          <div key={name} style={groupStyle}>
+            {group.render()}
+          </div>
+        );
+      });
+  }
+
+  renderEmpty() {
+    return <div style={styles.empty}>no groups available</div>;
+  }
+
+  render() {
+    if (!this.props.groups || !Object.keys(this.props.groups).length) {
+      return this.renderEmpty();
+    }
+    return (
+      <div style={styles.wrapper}>
+        <div style={styles.tabbar} role="tablist">
+          {this.renderTabs()}
+        </div>
+        <div style={styles.content}>{this.renderGroups()}</div>
+      </div>
+    );
+  }
+}
+
+GroupTabs.defaultProps = {
+  groups: {},
+  onGroupSelect: () => {},
+  selectedGroup: null,
+};
+
+GroupTabs.propTypes = {
+  groups: PropTypes.object, // eslint-disable-line react/forbid-prop-types
+  onGroupSelect: PropTypes.func,
+  selectedGroup: PropTypes.string,
+};
+
+export default GroupTabs;

--- a/addons/knobs/src/components/Panel.js
+++ b/addons/knobs/src/components/Panel.js
@@ -169,7 +169,9 @@ export default class Panel extends React.Component {
     const knobsArray = Object.keys(knobs)
       .filter(key => {
         const filter =
-          groupId === 'ALL' ? knobs[key].used : knobs[key].used && knobs[key].groupId === groupId;
+          groupId === DEFAULT_GROUP_ID
+            ? knobs[key].used
+            : knobs[key].used && knobs[key].groupId === groupId;
         return filter;
       })
       .map(key => knobs[key]);

--- a/addons/knobs/src/components/Panel.js
+++ b/addons/knobs/src/components/Panel.js
@@ -2,12 +2,13 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import debounce from 'lodash.debounce';
 
+import GroupTabs from './GroupTabs';
 import PropForm from './PropForm';
 import Types from './types';
 
-import AddonPanel from '../../../../lib/ui/src/modules/ui/components/addon_panel/index';
-
 const getTimestamp = () => +new Date();
+
+const DEFAULT_GROUP_ID = 'ALL';
 
 const styles = {
   panelWrapper: {
@@ -52,9 +53,9 @@ export default class Panel extends React.Component {
     this.setKnobs = this.setKnobs.bind(this);
     this.reset = this.reset.bind(this);
     this.setOptions = this.setOptions.bind(this);
-    this.onPanelSelect = this.onPanelSelect.bind(this);
+    this.onGroupSelect = this.onGroupSelect.bind(this);
 
-    this.state = { knobs: {}, groupId: 'ALL' };
+    this.state = { knobs: {}, groupId: DEFAULT_GROUP_ID };
     this.options = {};
 
     this.lastEdit = getTimestamp();
@@ -73,7 +74,7 @@ export default class Panel extends React.Component {
     this.stopListeningOnStory();
   }
 
-  onPanelSelect(name) {
+  onGroupSelect(name) {
     this.setState({ groupId: name });
   }
 
@@ -148,18 +149,18 @@ export default class Panel extends React.Component {
   render() {
     const { knobs, groupId } = this.state;
 
-    const groupIds = {
-      ALL: {
-        render: () => <div id="ALL">ALL</div>,
-        title: 'ALL',
-      },
+    const groups = {};
+
+    groups[DEFAULT_GROUP_ID] = {
+      render: () => <div id={DEFAULT_GROUP_ID}>{DEFAULT_GROUP_ID}</div>,
+      title: DEFAULT_GROUP_ID,
     };
 
     Object.keys(knobs)
       .filter(key => knobs[key].used && knobs[key].groupId)
       .forEach(key => {
         const keyGroupId = knobs[key].groupId;
-        groupIds[keyGroupId] = {
+        groups[keyGroupId] = {
           render: () => <div id={keyGroupId}>{keyGroupId}</div>,
           title: keyGroupId,
         };
@@ -179,10 +180,10 @@ export default class Panel extends React.Component {
 
     return (
       <div style={styles.panelWrapper}>
-        <AddonPanel
-          panels={groupIds}
-          onPanelSelect={this.onPanelSelect}
-          selectedPanel={this.state.groupId}
+        <GroupTabs
+          groups={groups}
+          onGroupSelect={this.onGroupSelect}
+          selectedGroup={this.state.groupId}
         />
         <div style={styles.panel}>
           <PropForm

--- a/addons/knobs/src/components/__tests__/GroupTabs.js
+++ b/addons/knobs/src/components/__tests__/GroupTabs.js
@@ -1,0 +1,58 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import GroupTabs from '../GroupTabs';
+
+describe('GroupTabs', () => {
+  test('should render only the selected group with display set other than "none"', () => {
+    const groups = {
+      test1: {
+        render() {
+          return <div id="test1">TEST 1</div>;
+        },
+      },
+      test2: {
+        render() {
+          return <div id="test2">TEST 2</div>;
+        },
+      },
+    };
+
+    const onGroupSelect = () => 'onGroupSelect';
+
+    const wrapper = shallow(
+      <GroupTabs groups={groups} onGroupSelect={onGroupSelect} selectedGroup="test2" />
+    );
+
+    expect(wrapper.find('#test1').parent()).toHaveStyle('display', 'none');
+    expect(wrapper.find('#test2').parent()).not.toHaveStyle('display', 'none');
+  });
+
+  test('should set onGroupSelected as onClick handlers of tabs', () => {
+    const groups = {
+      test1: {
+        render() {
+          return <div>TEST 1</div>;
+        },
+      },
+    };
+    const onGroupSelect = jest.fn();
+    const preventDefault = jest.fn();
+    const wrapper = shallow(
+      <GroupTabs groups={groups} onGroupSelect={onGroupSelect} selectedGroup="test1" />
+    );
+    wrapper.find('button').simulate('click', { preventDefault });
+
+    expect(onGroupSelect).toHaveBeenCalled();
+    expect(preventDefault).toHaveBeenCalled();
+  });
+
+  describe('when no groups are given', () => {
+    test('should render "no groups available"', () => {
+      const groups = {};
+      const onGroupSelect = () => 'onGroupSelect';
+      const wrapper = shallow(<GroupTabs groups={groups} onGroupSelect={onGroupSelect} />);
+
+      expect(wrapper.contains('no groups available')).toBe(true);
+    });
+  });
+});

--- a/examples/official-storybook/stories/addon-knobs.stories.js
+++ b/examples/official-storybook/stories/addon-knobs.stories.js
@@ -48,15 +48,15 @@ class AsyncItemLoader extends React.Component {
 storiesOf('Addons|Knobs.withKnobs', module)
   .addDecorator(withKnobs)
   .add('tweaks static values', () => {
-    const name = text('Name', 'Storyteller');
-    const age = number('Age', 70, { range: true, min: 0, max: 90, step: 5 });
+    const name = text('Name', 'Storyteller', 'GROUP-1');
+    const age = number('Age', 70, { range: true, min: 0, max: 90, step: 5 }, 'GROUP-1');
     const fruits = {
       apple: 'Apple',
       banana: 'Banana',
       cherry: 'Cherry',
     };
-    const fruit = select('Fruit', fruits, 'apple');
-    const dollars = number('Dollars', 12.5, { min: 0, max: 100, step: 0.01 });
+    const fruit = select('Fruit', fruits, 'apple', 'GROUP-1');
+    const dollars = number('Dollars', 12.5, { min: 0, max: 100, step: 0.01 }, 'GROUP-2');
     const years = number('Years in NY', 9);
 
     const backgroundColor = color('background', '#ffff00');

--- a/examples/official-storybook/stories/addon-knobs.stories.js
+++ b/examples/official-storybook/stories/addon-knobs.stories.js
@@ -49,27 +49,31 @@ storiesOf('Addons|Knobs.withKnobs', module)
   .addDecorator(withKnobs)
   .add('tweaks static values', () => {
     const name = text('Name', 'Storyteller', 'GROUP-1');
-    const age = number('Age', 70, { range: true, min: 0, max: 90, step: 5 }, 'GROUP-1');
+    const age = number('Age', 70, { range: true, min: 0, max: 90, step: 5 }, 'GROUP-2');
     const fruits = {
       apple: 'Apple',
       banana: 'Banana',
       cherry: 'Cherry',
     };
-    const fruit = select('Fruit', fruits, 'apple', 'GROUP-1');
-    const dollars = number('Dollars', 12.5, { min: 0, max: 100, step: 0.01 }, 'GROUP-2');
-    const years = number('Years in NY', 9);
+    const fruit = select('Fruit', fruits, 'apple', 'GROUP-3');
+    const dollars = number('Dollars', 12.5, { min: 0, max: 100, step: 0.01 }, 'GROUP-4');
+    const years = number('Years in NY', 9, {}, 'GROUP-5');
 
-    const backgroundColor = color('background', '#ffff00');
-    const items = array('Items', ['Laptop', 'Book', 'Whiskey']);
-    const otherStyles = object('Styles', {
-      border: '3px solid #ff00ff',
-      padding: '10px',
-    });
-    const nice = boolean('Nice', true);
+    const backgroundColor = color('background', '#ffff00', 'GROUP-6');
+    const items = array('Items', ['Laptop', 'Book', 'Whiskey'], ',', 'GROUP-7');
+    const otherStyles = object(
+      'Styles',
+      {
+        border: '3px solid #ff00ff',
+        padding: '10px',
+      },
+      'GROUP-8'
+    );
+    const nice = boolean('Nice', true, 'GROUP-9');
 
     // NOTE: the default value must not change - e.g., do not do date('Label', new Date()) or date('Label')
     const defaultBirthday = new Date('Jan 20 2017 GMT+0');
-    const birthday = date('Birthday', defaultBirthday);
+    const birthday = date('Birthday', defaultBirthday, 'GROUP-10');
 
     const intro = `My name is ${name}, I'm ${age} years old, and my favorite fruit is ${fruit}.`;
     const style = { backgroundColor, ...otherStyles };


### PR DESCRIPTION
Issue: #1896 

## What I did

- Added groupId argument to knob functions
- Created GroupTabs component (replica of AddonPanel in storybook/ui) within Knobs panel to serve as navigation when filtering between groups

## How to test
`groupId` has been added as the last argument to each of the knob functions (see updates to README)
```
text(label, defaultValue, groupId);
boolean(label, defaultValue, groupId);
number(label, defaultValue, options, groupId);
color(label, defaultValue, groupId);
object(label, defaultValue, groupId);
array(label, defaultValue, separator, groupId);
select(label, options, defaultValue, groupId);
date(label, defaultValue, groupId);
button(label, handler, groupId);
```

**NOTE: Knobs with optional arguments MUST have default values passed in for use with groupId.**

This was done to avoid breaking changes to current knob function contracts.

e.g. Notice these README updates:
- number(label, defaultValue, options, groupId);
- array(label, defaultValue, separator, groupId);

---

Is this testable with jest or storyshots?

Does this need a new example in the kitchen sink apps?

- Example usage has been provided in official-storybook app.

Does this need an update to the documentation?

- README has been updated with new argument.

If your answer is yes to any of these, please make sure to include it in your PR.

  
  
  
  
<img width="1437" alt="official-storybook" src="https://user-images.githubusercontent.com/4038373/34627165-881337e2-f22d-11e7-8aa4-b222b45b2d22.png">
